### PR TITLE
Store function key in secret variable.

### DIFF
--- a/getazurefunctionkey/script.ps1
+++ b/getazurefunctionkey/script.ps1
@@ -13,4 +13,4 @@ else {
     throw "Unknown key type to get $env:keyType"
 }
 
-Write-Host "##vso[task.setvariable variable=$env:functionKeyName;]$keyToOutput"
+Write-Host "##vso[task.setvariable variable=$env:functionKeyName;issecret=true]$keyToOutput"


### PR DESCRIPTION
When using the function key from this task in other devops tasks, sometimes they will print the code to the logs. This PR prevents the function key from appearing in plain text in such cases.